### PR TITLE
ENH: fix deprecated use of np.int and np.float

### DIFF
--- a/tikreg/models.py
+++ b/tikreg/models.py
@@ -694,9 +694,9 @@ def cvridge(Xtrain, Ytrain,
         max_point = map(max, max_point)
         # The maximum point
         kernmax, ridgemax = max_point
-        optima = np.asarray([[kernmax, ridgemax]], dtype=np.int)
+        optima = np.asarray([[kernmax, ridgemax]], dtype=int)
     else:
-        optima = np.zeros((nresponses, 2), dtype=np.int)
+        optima = np.zeros((nresponses, 2), dtype=int)
         for rdx in range(nresponses):
             kernmax, ridgemax = np.unravel_index(np.argmax(results[...,rdx].mean(0)),
                                                  (len(kernel_params), len(ridges)))
@@ -969,7 +969,7 @@ def crossval_stem_wmvnp(features_train,
                        )
 
     if predictions or weights:
-        sample_counter = np.zeros(responses_train.shape[0]).astype(np.int)
+        sample_counter = np.zeros(responses_train.shape[0]).astype(int)
         for ifold, (trnidx, validx) in enumerate(folds):
             sample_counter[validx] += 1
         sample_max = sample_counter.max()
@@ -992,7 +992,7 @@ def crossval_stem_wmvnp(features_train,
 
     # start iterating through spatio-temporal hyparams
     for hyperidx, spatiotemporal_hyperparams in enumerate(all_hyperparams):
-        sample_counter = np.zeros(responses_train.shape[0]).astype(np.int)
+        sample_counter = np.zeros(responses_train.shape[0]).astype(int)
 
         # hyhperparameters
         temporal_hhparam = spatiotemporal_hyperparams[0]
@@ -1102,12 +1102,12 @@ def crossval_stem_wmvnp(features_train,
             print(txt % contents)
 
     #### dimensions explored
-    dtype = np.dtype([('nfolds', np.int),
-                      ('ntemporal_hhparams', np.int),
-                      ('nspatial_hyparams', np.int),
-                      ('nridges', np.int),
-                      ('nresponses', np.int),
-                      ('nfspaces', np.int)])
+    dtype = np.dtype([('nfolds', int),
+                      ('ntemporal_hhparams', int),
+                      ('nspatial_hyparams', int),
+                      ('nridges', int),
+                      ('nresponses', int),
+                      ('nfspaces', int)])
 
     dims = np.recarray(shape=(1), dtype=dtype)
     dims[0] = np.asarray([(nfolds,

--- a/tikreg/utils.py
+++ b/tikreg/utils.py
@@ -559,7 +559,7 @@ def explainable_variance(repeats, ncorrection=True, dozscore=True):
     ev = 1 - residualvar
 
     if ncorrection:
-        ev = ev - ((1 - ev) / np.float((repeats.shape[0] - 1)))
+        ev = ev - ((1 - ev) / float((repeats.shape[0] - 1)))
     return ev
 
 
@@ -920,7 +920,7 @@ def hrf_convolution(input_responses, HRF=None, do_convolution=True, dt=None):
     if input_responses.ndim == 1:
         input_responses = input_responses[...,None]
 
-    bold = np.zeros_like(input_responses).astype(np.float)
+    bold = np.zeros_like(input_responses).astype(float)
     nresp = input_responses.shape[-1]
 
     if HRF is None:


### PR DESCRIPTION
Just replaces np.int with int and np.float with float. This enables use of tikreg with newer versions of numpy.